### PR TITLE
changed ContentLength and LastModified

### DIFF
--- a/src/OCIStorageService.js
+++ b/src/OCIStorageService.js
@@ -164,10 +164,10 @@ export class OCIStorageService extends BaseStorageService {
                 responseData[(_.get(blob, 'error.reportname'))] = blob.error
               } else {
                 responseData[(_.get(blob, 'value.reportname'))] = {
-                  lastModified: _.get(blob, 'value.lastModified'),
+                  lastModified: _.get(blob, 'value.LastModified'),
                   reportname: _.get(blob, 'value.reportname'),
                   statusCode: _.get(blob, 'value.statusCode'),
-                  fileSize: _.get(blob, 'value.contentLength')
+                  fileSize: _.get(blob, 'value.ContentLength')
                 }
               }
             });


### PR DESCRIPTION
@heungheung 

Please review this change. I think the issue here that in the method HeadObjectCommand, the return values are
ContentLength
LastModified

https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/classes/headobjectcommand.html


In case of Azure Implementation this comes from blobService.getBlobProperties which is
lastModified
contentLength
https://azure.github.io/azure-storage-node/BlobResult.html

The issue here is that when the getFileProperties() is called , the reponse is not having the value for lastModified
and fileSize

I believe this is the cause of the issue described in 
https://github.com/orgs/Sunbird-Ed/discussions/481



